### PR TITLE
Remove unused ReportGenerator dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,4 +258,4 @@ Both modes share the same `InMemoryAwsBus` instance but exercise different code 
 
 Uses Central Package Management (Directory.Packages.props):
 - All package versions defined centrally
-- Test projects automatically get TUnit, coverage tools, and ReportGenerator via `IsTestProject=true`
+- Test projects automatically get TUnit and coverage tools via `IsTestProject=true`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.7" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.7" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.7" />
@@ -23,6 +22,5 @@
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="All" />
     <PackageReference Include="TUnit" />
-    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Drops the `ReportGenerator` package from `Directory.Packages.props` (both the central `PackageVersion` and the `IsTestProject=true` `PackageReference`).
- Updates `CLAUDE.md` to no longer claim test projects pull in ReportGenerator.

The package was wired up for test projects but never invoked: `build.ps1` only emits `coverage.cobertura.xml`, and CI (`.github/workflows/build.yml`) uploads that straight to Codecov. Removing it also stops Renovate from opening recurring update PRs for it.

## Test plan
- [x] `dotnet build tests/LocalSqsSnsMessaging.Tests/LocalSqsSnsMessaging.Tests.csproj -c Release` succeeds with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)