### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <VersionPrefix>0.8.4</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' AND '$(DEPENDABOT_JOB_ID)' == '' ">
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>


### PR DESCRIPTION
## Summary
- Bumps `VersionPrefix` in `Directory.Build.props` from `0.8.4` to `1.0.0` in preparation for the first stable release.

## Release process (for reference)
After merge to `main`:
1. Run the **release** workflow (`workflow_dispatch`) with `publish: true` to skip the draft state. It will read `VersionPrefix` and create a `v1.0.0` GitHub release/tag.
2. The tag push triggers `build.yml`, which packs and runs the `publish-nuget` job to push to NuGet.org via OIDC.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, trigger `release` workflow and verify `v1.0.0` tag + release
- [ ] Verify `build.yml` `publish-nuget` job pushes `LocalSqsSnsMessaging 1.0.0` to NuGet.org