### PR TITLE
Swap Floci for jet-stack 1.0.0-rc.5 in verification suite

### DIFF
--- a/tests/LocalSqsSnsMessaging.Tests.Verification/ExternalVerification/SnsPublishAsyncTestsVerification.cs
+++ b/tests/LocalSqsSnsMessaging.Tests.Verification/ExternalVerification/SnsPublishAsyncTestsVerification.cs
@@ -20,8 +20,5 @@ public class SnsPublishAsyncTestsVerification : SnsPublishAsyncTests
         SnsForTeardown = Sns;
     }
 
-    // Floci surfaces attribute-size overflows as the base InvalidParameterException
-    // rather than the typed InvalidParameterValueException that real AWS returns,
-    // so only assert the typed variant when actually pointed at AWS.
-    protected override bool SupportsAttributeSizeValidation() => IsRealAwsMode;
+    protected override bool SupportsAttributeSizeValidation() => true;
 }

--- a/tests/LocalSqsSnsMessaging.Tests.Verification/FlociAspireExtensions.cs
+++ b/tests/LocalSqsSnsMessaging.Tests.Verification/FlociAspireExtensions.cs
@@ -9,7 +9,7 @@ public static class FlociAspireExtensions
     {
         var flociResource =
             builder
-                .AddContainer("floci", "floci/floci", "latest")
+                .AddContainer("floci", "ghcr.io/justeattakeaway/jet-stack", "1.0.0-rc.5")
                 .WithHttpEndpoint(targetPort: 4566)
                 .WithFlociHealthCheck();
 


### PR DESCRIPTION
## Summary
- Swaps the verification-suite container image from `floci/floci:latest` to `ghcr.io/justeattakeaway/jet-stack:1.0.0-rc.5`. jet-stack rc.5 fixes the SQS `MaximumMessageSize=1048576` rejection and the silently-accepted-null `TagQueue` value that Floci diverged on ([justeattakeaway/jet-stack#100](https://github.com/justeattakeaway/jet-stack/issues/100)).
- Simplifies the SNS attribute-size predicate to always expect `InvalidParameterValueException`, since jet-stack matches real AWS here (Floci's looser typing was the reason for the conditional).
- All 87 verification tests pass against jet-stack rc.5.

## Test plan
- [ ] `cd tests/LocalSqsSnsMessaging.Tests.Verification && dotnet run -c Release -- --timeout 5m --no-progress --log-level Warning` passes 87/87
- [ ] CI green