### PR TITLE
Add trace activity to WaitAsync test helper

### DIFF
--- a/tests/LocalSqsSnsMessaging.Tests.Shared/TracerProviderInitializer.cs
+++ b/tests/LocalSqsSnsMessaging.Tests.Shared/TracerProviderInitializer.cs
@@ -15,6 +15,7 @@ internal static class TracerProviderInitializer
     {
         TracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddSource("LocalSqsSnsMessaging")
+            .AddSource(WaitingTestBase.ActivitySourceName)
             .AddAWSInstrumentation()
             .Build();
     }

--- a/tests/LocalSqsSnsMessaging.Tests.Shared/WaitingTestBase.cs
+++ b/tests/LocalSqsSnsMessaging.Tests.Shared/WaitingTestBase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS;
@@ -12,6 +13,14 @@ public abstract class WaitingTestBase
 {
     protected const string TimeBased = ApplyDefaultCategoryAttribute.TimeBasedCategoryName;
     protected TimeProvider TimeProvider = TimeProvider.System;
+
+    /// <summary>
+    /// Activity source for test-scaffolding spans (e.g. explicit waits). Registered with the
+    /// trace pipeline in <see cref="TracerProviderInitializer"/> so the spans surface in the
+    /// OTEL traces attached to TUnit test reports.
+    /// </summary>
+    internal const string ActivitySourceName = "LocalSqsSnsMessaging.Tests";
+    private static readonly ActivitySource ActivitySource = new(ActivitySourceName);
 
     /// <summary>
     /// True when the test run targets real AWS (the verification project sets this via
@@ -230,7 +239,7 @@ public abstract class WaitingTestBase
         return allMessages;
     }
 
-    protected Task WaitAsync(TimeSpan timeSpan)
+    protected async Task WaitAsync(TimeSpan timeSpan)
     {
         var categories = TestContext.Current?.Metadata.TestDetails.Categories;
         if (categories is null || !categories.Contains(TimeBased, StringComparer.OrdinalIgnoreCase))
@@ -238,12 +247,21 @@ public abstract class WaitingTestBase
             throw new InvalidOperationException("This method should only be called for tests marked with the 'TimeBased' category.");
         }
 
-        if (TimeProvider is FakeTimeProvider fakeTimeProvider)
+        var fake = TimeProvider as FakeTimeProvider;
+
+        // Span covers the actual wait so its duration shows up in the trace. For a
+        // FakeTimeProvider the advance is instantaneous, so the span just marks that
+        // the test logically waited; for real time it spans the elapsed delay.
+        using var activity = ActivitySource.StartActivity("WaitAsync");
+        activity?.SetTag("wait.duration_ms", timeSpan.TotalMilliseconds);
+        activity?.SetTag("wait.mode", fake is not null ? "fake-advance" : "real-delay");
+
+        if (fake is not null)
         {
-            fakeTimeProvider.Advance(timeSpan);
-            return Task.CompletedTask;
+            fake.Advance(timeSpan);
+            return;
         }
 
-        return Task.Delay(timeSpan, TimeProvider);
+        await Task.Delay(timeSpan, TimeProvider);
     }
 }


### PR DESCRIPTION
Explicit waits in time-based tests now emit a `WaitAsync` span via a new `LocalSqsSnsMessaging.Tests` activity source, so they surface in the OTEL traces attached to TUnit test reports. The `WaitAsync` helper is made `async` so the span covers the actual delay duration, and each span is tagged with the requested duration and whether time was faked or real. The new activity source is registered in `TracerProviderInitializer` so the trace pipeline captures it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)